### PR TITLE
Rename Wechat to WeChat

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # matrix-wechat
-A Matrix-Wechat puppeting bridge based on [mautrix-go](https://github.com/mautrix/go).
+A Matrix-WeChat puppeting bridge based on [mautrix-go](https://github.com/mautrix/go).
 
 ### Documentation
 
@@ -12,7 +12,7 @@ Some quick links:
 
 ### Features & roadmap
 
-* Matrix → Wechat
+* Matrix → WeChat
   * [ ] Message types
     * [x] Text
 	* [x] Image
@@ -42,7 +42,7 @@ Some quick links:
     * [ ] Name
     * [ ] Avatar
 
-* Wechat → Matrix
+* WeChat → Matrix
   * [ ] Message types
     * [x] Text
     * [x] Image

--- a/example-config.yaml
+++ b/example-config.yaml
@@ -52,7 +52,7 @@ appservice:
         username: wechatbot
         # Display name and avatar for bot. Set to "remove" to remove display name/avatar, leave empty
         # to leave display name/avatar as-is.
-        displayname: Wechat bridge bot
+        displayname: WeChat bridge bot
         avatar: mxc://matrix.org/rddVQBTjOOmNkNLXWfYJNfPW
 
     # Whether or not to receive ephemeral events via appservice transactions.
@@ -66,11 +66,11 @@ appservice:
 
 # Bridge config
 bridge:
-    # Localpart template of MXIDs for Wechat users.
+    # Localpart template of MXIDs for WeChat users.
     username_template: _wechat_{{.}}
-    # Displayname template for Wechat users.
-    displayname_template: "{{if .Name}}{{.Name}}{{else}}{{.Uin}}{{end}} (Wechat)"
-    # Wechat listen address (for agent connection)
+    # Displayname template for WeChat users.
+    displayname_template: "{{if .Name}}{{.Name}}{{else}}{{.Uin}}{{end}} (WeChat)"
+    # WeChat listen address (for agent connection)
     listen_address: "0.0.0.0:20002"
     listen_secret: foobar
     # Should the bridge create a space for each logged-in user and add bridged rooms to it?
@@ -95,9 +95,9 @@ bridge:
     # presence is bridged. These settings set the default values.
     # Existing users won't be affected when these are changed.
     default_bridge_presence: false
-    # Send the presence as "available" to Wechat when users start typing on a portal.
+    # Send the presence as "available" to WeChat when users start typing on a portal.
     # This works as a workaround for homeservers that do not support presence, and allows
-    # users to see when the Wechat user on the other side is typing during a conversation.
+    # users to see when the WeChat user on the other side is typing during a conversation.
     send_presence_on_typing: false
     # Servers to always allow double puppeting from
     double_puppet_server_map:
@@ -120,7 +120,7 @@ bridge:
     resend_bridge_info: false
     # When using double puppeting, should muted chats be muted in Matrix?
     mute_bridging: false
-    # Allow invite permission for user. User can invite any bots to room with Wechat
+    # Allow invite permission for user. User can invite any bots to room with WeChat
     # users (private chat and groups)
     allow_user_invite: false
     # Whether or not created rooms should have federation enabled.
@@ -147,7 +147,7 @@ bridge:
     # Markdown is supported. The defaults are listed below.
     management_room_text:
         # Sent when joining a room.
-        welcome: "Hello, I'm a Wechat bridge bot."
+        welcome: "Hello, I'm a WeChat bridge bot."
         # Sent when joining a management room and the user is already logged in.
         welcome_connected: "Use `help` for help."
         # Sent when joining a management room and the user is not logged in.
@@ -183,7 +183,7 @@ bridge:
         #   verified - Require manual per-device verification
         #              (currently only possible by modifying the `trust` column in the `crypto_device` database table).
         verification_levels:
-            # Minimum level for which the bridge should send keys to when bridging messages from Wechat to Matrix.
+            # Minimum level for which the bridge should send keys to when bridging messages from WeChat to Matrix.
             receive: unverified
             # Minimum level that the bridge should accept for incoming Matrix messages.
             send: unverified
@@ -209,7 +209,7 @@ bridge:
 
     # Permissions for using the bridge.
     # Permitted values:
-    #     user - Access to use the bridge to chat with a Wechat account.
+    #     user - Access to use the bridge to chat with a WeChat account.
     #    admin - User level and some additional administration tools
     # Permitted keys:
     #        * - All Matrix users

--- a/internal/bridgestate.go
+++ b/internal/bridgestate.go
@@ -14,9 +14,9 @@ const (
 func init() {
 	status.BridgeStateHumanErrors.Update(status.BridgeStateErrorMap{
 		WechatLoggedOut:        "You were logged out from another device. Relogin to continue using the bridge.",
-		WechatNotConnected:     "You're not connected to Wechat.",
-		WechatConnecting:       "Reconnecting to Wechat...",
-		WechatConnectionFailed: "Connect to the Wechat servers failed.",
+		WechatNotConnected:     "You're not connected to WeChat.",
+		WechatConnecting:       "Reconnecting to WeChat...",
+		WechatConnectionFailed: "Connect to the WeChat servers failed.",
 	})
 }
 

--- a/internal/command.go
+++ b/internal/command.go
@@ -67,7 +67,7 @@ var cmdLogin = &commands.FullHandler{
 	Name: "login",
 	Help: commands.HelpMeta{
 		Section:     commands.HelpSectionAuth,
-		Description: "Link the bridge to your Wechat account.",
+		Description: "Link the bridge to your WeChat account.",
 	},
 }
 
@@ -128,7 +128,7 @@ func fnLogin(ce *WrappedCommandEvent) {
 						if !ce.User.IsLoggedIn() {
 							if count == maxCheckCount {
 								ce.User.DeleteConnection()
-								ce.Reply("You're not logged into Wechat.")
+								ce.Reply("You're not logged into WeChat.")
 								return
 							}
 							count += 1
@@ -190,20 +190,20 @@ var cmdLogout = &commands.FullHandler{
 	Name: "logout",
 	Help: commands.HelpMeta{
 		Section:     commands.HelpSectionAuth,
-		Description: "Unlink the bridge from your Wechat account.",
+		Description: "Unlink the bridge from your WeChat account.",
 	},
 }
 
 func fnLogout(ce *WrappedCommandEvent) {
 	if !ce.User.IsLoggedIn() {
-		ce.Reply("You are not connected to Wechat.")
+		ce.Reply("You are not connected to WeChat.")
 		return
 	}
 	puppet := ce.Bridge.GetPuppetByUID(ce.User.UID)
 	if puppet.CustomMXID != "" {
 		err := puppet.SwitchCustomMXID("", "")
 		if err != nil {
-			ce.User.log.Warnln("Failed to logout-matrix while logging out of Wechat:", err)
+			ce.User.log.Warnln("Failed to logout-matrix while logging out of WeChat:", err)
 		}
 	}
 	ce.User.Client.Disconnect()
@@ -218,15 +218,15 @@ var cmdPing = &commands.FullHandler{
 	Name: "ping",
 	Help: commands.HelpMeta{
 		Section:     HelpSectionConnectionManagement,
-		Description: "Check your connection to Wechat.",
+		Description: "Check your connection to WeChat.",
 	},
 }
 
 func fnPing(ce *WrappedCommandEvent) {
 	if ce.User.IsLoggedIn() {
-		ce.Reply("Logged in as %s, connection to Wechat OK (probably)", ce.User.UID.Uin)
+		ce.Reply("Logged in as %s, connection to WeChat OK (probably)", ce.User.UID.Uin)
 	} else {
-		ce.Reply("You're not logged into Wechat.")
+		ce.Reply("You're not logged into WeChat.")
 	}
 }
 
@@ -484,7 +484,7 @@ var cmdSync = &commands.FullHandler{
 	Name: "sync",
 	Help: commands.HelpMeta{
 		Section:     HelpSectionMiscellaneous,
-		Description: "Synchronize data from Wechat.",
+		Description: "Synchronize data from WeChat.",
 		Args:        "<contacts/groups/space> [--contact-avatars] [--create-portals]",
 	},
 	RequiresLogin: true,

--- a/internal/custompuppet.go
+++ b/internal/custompuppet.go
@@ -56,8 +56,8 @@ func (p *Puppet) loginWithSharedSecret(mxid id.UserID) (string, error) {
 	}
 	req := mautrix.ReqLogin{
 		Identifier:               mautrix.UserIdentifier{Type: mautrix.IdentifierTypeUser, User: string(mxid)},
-		DeviceID:                 "Wechat Bridge",
-		InitialDeviceDisplayName: "Wechat Bridge",
+		DeviceID:                 "WeChat Bridge",
+		InitialDeviceDisplayName: "WeChat Bridge",
 	}
 	if loginSecret == "appservice" {
 		client.AccessToken = p.bridge.AS.Registration.AppToken

--- a/internal/portal.go
+++ b/internal/portal.go
@@ -37,7 +37,7 @@ import (
 )
 
 const (
-	PrivateChatTopic      = "Wechat private chat"
+	PrivateChatTopic      = "WeChat private chat"
 	recentlyHandledLength = 100
 )
 
@@ -579,7 +579,7 @@ func (p *Portal) kickExtraUsers(participantMap map[types.UID]bool) {
 			if !shouldBePresent {
 				_, err = p.MainIntent().KickUser(p.MXID, &mautrix.ReqKickUser{
 					UserID: member,
-					Reason: "User had left this Wechat chat",
+					Reason: "User had left this WeChat chat",
 				})
 				if err != nil {
 					p.log.Warnfln("Failed to kick user %s who had left: %v", member, err)
@@ -965,7 +965,7 @@ func (p *Portal) getBridgeInfo() (string, event.BridgeEventContent) {
 		Creator:   p.MainIntent().UserID,
 		Protocol: event.BridgeInfoSection{
 			ID:          "wechat",
-			DisplayName: "Wechat",
+			DisplayName: "WeChat",
 			AvatarURL:   p.bridge.Config.AppService.Bot.ParsedAvatar.CUString(),
 			ExternalURL: "https://www.wechat.com/",
 		},
@@ -1431,11 +1431,11 @@ func (p *Portal) HandleMatrixMessage(sender *User, evt *event.Event) {
 	}
 
 	msgID := "FAKE::" + strconv.FormatInt(evt.Timestamp, 10)
-	p.log.Debugln("Sending event", evt.ID, "to Wechat")
+	p.log.Debugln("Sending event", evt.ID, "to WeChat")
 	if err := sender.Client.SendMessage(msg); err != nil {
-		p.log.Warnfln("Sending event", evt.ID, "to Wechat failed")
+		p.log.Warnfln("Sending event", evt.ID, "to WeChat failed")
 	} else {
-		// TODO: get msgID from Wechat
+		// TODO: get msgID from WeChat
 		p.finishHandling(nil, msgID, time.UnixMilli(evt.Timestamp), sender.UID, evt.ID, database.MsgNormal, database.MsgNoError)
 	}
 }

--- a/internal/user.go
+++ b/internal/user.go
@@ -231,8 +231,8 @@ func (u *User) GetSpaceRoom() id.RoomID {
 
 		resp, err := u.bridge.Bot.CreateRoom(&mautrix.ReqCreateRoom{
 			Visibility: "private",
-			Name:       "Wechat",
-			Topic:      "Your Wechat bridged chats",
+			Name:       "WeChat",
+			Topic:      "Your WeChat bridged chats",
 			InitialState: []*event.Event{{
 				Type: event.StateRoomAvatar,
 				Content: event.Content{
@@ -280,7 +280,7 @@ func (u *User) GetManagementRoom() id.RoomID {
 			creationContent["m.federate"] = false
 		}
 		resp, err := u.bridge.Bot.CreateRoom(&mautrix.ReqCreateRoom{
-			Topic:           "Wechat bridge notices",
+			Topic:           "WeChat bridge notices",
 			IsDirect:        true,
 			CreationContent: creationContent,
 		})
@@ -307,7 +307,7 @@ func (u *User) SetManagementRoom(roomID id.RoomID) {
 }
 
 func (u *User) failedConnect(err error) {
-	u.log.Warnln("Error connecting to Wechat:", err)
+	u.log.Warnln("Error connecting to WeChat:", err)
 	u.Client.Disconnect()
 	u.BridgeState.Send(status.BridgeState{
 		StateEvent: status.StateUnknownError,

--- a/main.go
+++ b/main.go
@@ -26,7 +26,7 @@ func main() {
 	br.Bridge = bridge.Bridge{
 		Name:         "matrix-wechat",
 		URL:          "https://github.com/duo/matrix-wechat",
-		Description:  "A Matrix-Wechat puppeting bridge.",
+		Description:  "A Matrix-WeChat puppeting bridge.",
 		Version:      "0.1.0",
 		ProtocolName: "Wechat",
 


### PR DESCRIPTION
Rename all `Wechat` in strings to `WeChat`.

The official English name of **微信** is **WeChat**, not Wechat.

I renamed every `Wechat` in strings to `WeChat`, and keep `Wechat` in identifiers (function name, variable name, etc.).
