### PR TITLE
Use audio filter instead of vol

### DIFF
--- a/internal/util.go
+++ b/internal/util.go
@@ -172,7 +172,7 @@ func silk2ogg(rawData []byte) ([]byte, error) {
 	defer os.Remove(wavFile.Name())
 	{
 		cmd := exec.Command(
-			"ffmpeg", "-f", "s16le", "-ar", "24000", "-ac", "1", "-vol", "2000", "-y", "-i", pcmFile.Name(), "-f", "wav", wavFile.Name())
+			"ffmpeg", "-f", "s16le", "-ar", "24000", "-ac", "1", "-y", "-i", pcmFile.Name(), "-f", "wav", "-af", "volume=7.812500", wavFile.Name())
 		if err := cmd.Start(); err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
`-vol` is deprecated and removed in ffmpeg 6.0. I've changed the `-vol` flag to `-af` according to ffmpeg 5.1.3's log:
```
ffmpeg version 5.1.3 Copyright (c) 2000-2022 the FFmpeg developers
  built with gcc 12.2.1 (Alpine 12.2.1_git20220924-r4) 20220924
  configuration: --prefix=/usr --enable-avfilter --enable-libfontconfig --enable-libfreetype --enable-libfribidi --enable-gnutls --enable-gpl --enable-libass --enable-libmp3lame --enable-libpulse --enable-libvorbis --enable-libvpx --enable-libxvid --enable-libx264 --enable-libx265 --enable-libtheora --enable-libv4l2 --enable-libdav1d --enable-lto --enable-postproc --enable-pic --enable-pthreads --enable-shared --enable-libxcb --enable-librist --enable-libsrt --enable-libssh --enable-libvidstab --disable-stripping --disable-static --disable-librtmp --disable-lzma --enable-libaom --enable-libopus --enable-libsoxr --enable-libwebp --enable-vaapi --enable-vdpau --enable-vulkan --enable-libdrm --enable-libzmq --optflags=-O2 --disable-debug --enable-libsvtav1
  libavutil      57. 28.100 / 57. 28.100
  libavcodec     59. 37.100 / 59. 37.100
  libavformat    59. 27.100 / 59. 27.100
  libavdevice    59.  7.100 / 59.  7.100
  libavfilter     8. 44.100 /  8. 44.100
  libswscale      6.  7.100 /  6.  7.100
  libswresample   4.  7.100 /  4.  7.100
  libpostproc    56.  6.100 / 56.  6.100
[s16le @ 0x6483f591f140] Estimating duration from bitrate, this may be inaccurate
Guessed Channel Layout for Input Stream #0.0 : mono
Input #0, s16le, from '/tmp/pcm-3808134229':
  Duration: 00:00:01.76, bitrate: 384 kb/s
  Stream #0:0: Audio: pcm_s16le, 24000 Hz, mono, s16, 384 kb/s
Stream mapping:
  Stream #0:0 -> #0:0 (pcm_s16le (native) -> pcm_s16le (native))
Press [q] to stop, [?] for help
-vol has been deprecated. Use the volume audio filter instead.
-vol is forwarded to lavfi similarly to -af volume=7.812500.
Output #0, wav, to '/tmp/wav-1073214999':
  Metadata:
    ISFT            : Lavf59.27.100
  Stream #0:0: Audio: pcm_s16le ([1][0][0][0] / 0x0001), 24000 Hz, mono, s16, 384 kb/s
    Metadata:
      encoder         : Lavc59.37.100 pcm_s16le
size=      83kB time=00:00:01.76 bitrate= 384.4kbits/s speed=1.04e+03x    
video:0kB audio:82kB subtitle:0kB other streams:0kB global headers:0kB muxing overhead: 0.092330%
```